### PR TITLE
Add hypothesis tests and bounds checks on Integers

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,13 +5,12 @@ name: Python package
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -19,17 +18,17 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - uses: pre-commit/action@v3.0.1
-    - name: Test with pytest
-      run: |
-        pytest
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[test]"
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - uses: pre-commit/action@v3.0.1
+      - name: Test with pytest
+        run: |
+          pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,21 @@ dynamic = ["version", "description"]
 
 [project.urls]
 Home = "https://github.com/adafruit/circuitmatter"
+"Bug Tracker" = "https://github.com/adafruit/circuitmatter/issues"
+
+[project.optional-dependencies]
+test = [
+    "hypothesis",
+    "pytest",
+    "pytest-cov",
+    # "typing_extensions",
+]
+
+[tool.coverage.run]
+branch = true
+source = [
+    "circuitmatter",
+]
 
 [tool.pytest.ini_options]
 pythonpath = [


### PR DESCRIPTION
These are the kind of tests I meant during the Deep Dive stream.

Writing them they let me discover there were no bounds checks.
I leave it as an exercise to the reader to add the round trip tests for signed integers and other bit-sized unsigned integers.

I haven't gotten to the more interesting cases: the nested structures. Hypothesis can be used to create arbitrary nested structures for these.