### PR TITLE
Stricter types

### DIFF
--- a/circuitmatter/tlv.py
+++ b/circuitmatter/tlv.py
@@ -4,7 +4,19 @@ import enum
 import math
 import struct
 from abc import ABC, abstractmethod
-from typing import AnyStr, Generic, Iterable, Literal, Optional, Type, TypeVar, overload
+from typing import (
+    AnyStr,
+    Generic,
+    Iterable,
+    Literal,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
+
+from typing_extensions import Buffer
 
 # As a byte string to save space.
 TAG_LENGTH = b"\x00\x01\x02\x04\x02\x04\x06\x08"
@@ -28,8 +40,8 @@ class ElementType(enum.IntEnum):
 class TLVStructure:
     _max_length = None
 
-    def __init__(self, buffer: Optional[bytes] = None):
-        self.buffer = buffer
+    def __init__(self, buffer: Optional[Buffer] = None):
+        self.buffer = memoryview(buffer) if buffer is not None else None
         # These three dicts are keyed by tag.
         self.tag_value_offset = {}
         self.null_tags = set()
@@ -40,14 +52,12 @@ class TLVStructure:
     @classmethod
     def max_length(cls):
         if cls._max_length is None:
-            cls._max_length = 0
-            for _field, descriptor_class in cls._members(cls):
-                cls._max_length += descriptor_class.max_length
+            cls._max_length = sum(member.max_length for _, member in cls._members())
         return cls._max_length
 
     def __str__(self):
         members = []
-        for field, descriptor_class in self._members(type(self)):
+        for field, descriptor_class in self._members():
             value = descriptor_class.print(self)
             if isinstance(descriptor_class, StructMember):
                 value = value.replace("\n", "\n  ")
@@ -59,14 +69,14 @@ class TLVStructure:
         end = self.encode_into(buffer)
         return memoryview(buffer)[:end]
 
-    def encode_into(self, buffer, offset: int = 0):
-        for _, descriptor_class in self._members(type(self)):
+    def encode_into(self, buffer: bytearray, offset: int = 0) -> int:
+        for _, descriptor_class in self._members():
             offset = descriptor_class.encode_into(self, buffer, offset)
         return offset
 
-    @staticmethod
-    def _members(class_: Type) -> Iterable[tuple[str, Member]]:
-        for field_name, descriptor in vars(class_).items():
+    @classmethod
+    def _members(cls) -> Iterable[tuple[str, Member]]:
+        for field_name, descriptor in vars(cls).items():
             if not field_name.startswith("_") and isinstance(descriptor, Member):
                 yield field_name, descriptor
 
@@ -170,12 +180,20 @@ class TLVStructure:
 
 _T = TypeVar("_T")
 _NULLABLE = TypeVar("_NULLABLE", Literal[True], Literal[False])
+_OPT = TypeVar("_OPT", Literal[True], Literal[False])
 
 
-class Member(ABC, Generic[_T, _NULLABLE]):
+class Member(ABC, Generic[_T, _OPT, _NULLABLE]):
     max_value_length: int = 0
 
-    def __init__(self, tag, *, optional: bool = False, nullable: _NULLABLE = False):
+    def __init__(
+        self, tag, *, optional: _OPT = False, nullable: _NULLABLE = False
+    ) -> None:
+        """
+        :param optional: Indicates whether the value MAY be omitted from the encoding.
+                         Can be used for deprecation.
+        :param nullable: Indicates whether a TLV Null MAY be encoded in place of a value.
+        """
         self.tag = tag
         self.optional = optional
         self.nullable = nullable
@@ -192,14 +210,16 @@ class Member(ABC, Generic[_T, _NULLABLE]):
 
     @overload
     def __get__(
-        self: Member[_T, Literal[True]],
+        self: Union[
+            Member[_T, Literal[True], _NULLABLE], Member[_T, _OPT, Literal[True]]
+        ],
         obj: TLVStructure,
         objtype: Optional[Type[TLVStructure]] = None,
     ) -> Optional[_T]: ...
 
     @overload
     def __get__(
-        self: Member[_T, Literal[False]],
+        self: Member[_T, Literal[False], Literal[False]],
         obj: TLVStructure,
         objtype: Optional[Type[TLVStructure]] = None,
     ) -> _T: ...
@@ -222,11 +242,15 @@ class Member(ABC, Generic[_T, _NULLABLE]):
 
     @overload
     def __set__(
-        self: Member[_T, Literal[True]], obj: TLVStructure, value: Optional[_T]
+        self: Union[
+            Member[_T, Literal[True], _NULLABLE], Member[_T, _OPT, Literal[True]]
+        ],
+        obj: TLVStructure,
+        value: Optional[_T],
     ) -> None: ...
     @overload
     def __set__(
-        self: Member[_T, Literal[False]], obj: TLVStructure, value: _T
+        self: Member[_T, Literal[False], Literal[False]], obj: TLVStructure, value: _T
     ) -> None: ...
     def __set__(self, obj, value):
         if value is None and not self.nullable:
@@ -258,14 +282,14 @@ class Member(ABC, Generic[_T, _NULLABLE]):
             return new_offset
         return offset
 
-    def print(self, obj):
+    def print(self, obj: TLVStructure) -> str:
         value = self.__get__(obj)  # type: ignore  # self inference issues
         if value is None:
             return "null"
         return self._print(value)
 
     @abstractmethod
-    def decode(self, buffer, length: int, offset: int = 0) -> _T:
+    def decode(self, buffer: memoryview, length: int, offset: int = 0) -> _T:
         "Return the decoded value at `offset` in `buffer`"
         ...
 
@@ -277,15 +301,25 @@ class Member(ABC, Generic[_T, _NULLABLE]):
     @overload
     @abstractmethod
     def encode_value_into(
-        self: Member[_T, Literal[True]], value: Optional[_T], buffer, offset: int
+        self: Union[
+            Member[_T, Literal[True], _NULLABLE], Member[_T, _OPT, Literal[True]]
+        ],
+        value: Optional[_T],
+        buffer: bytearray,
+        offset: int,
     ) -> int: ...
     @overload
     @abstractmethod
     def encode_value_into(
-        self: Member[_T, Literal[False]], value: _T, buffer, offset: int
+        self: Member[_T, Literal[False], Literal[False]],
+        value: _T,
+        buffer: bytearray,
+        offset: int,
     ) -> int: ...
     @abstractmethod
-    def encode_value_into(self, value, buffer, offset: int) -> int:
+    def encode_value_into(
+        self, value: Optional[_T], buffer: bytearray, offset: int
+    ) -> int:
         "Encode `value` into `buffer` and return the new offset"
         ...
 
@@ -299,8 +333,15 @@ class Member(ABC, Generic[_T, _NULLABLE]):
 _NT = TypeVar("_NT", float, int)
 
 
-class NumberMember(Member[_NT, _NULLABLE], Generic[_NT, _NULLABLE]):
-    def __init__(self, tag, _format: str, nullable: _NULLABLE = False, **kwargs):
+class NumberMember(Member[_NT, _OPT, _NULLABLE], Generic[_NT, _OPT, _NULLABLE]):
+    def __init__(
+        self,
+        tag,
+        _format: str,
+        optional: _OPT = False,
+        nullable: _NULLABLE = False,
+        **kwargs,
+    ):
         self.format = _format
         self.integer = _format[-1].upper() in INT_SIZE
         self.signed = self.format.islower()
@@ -314,7 +355,7 @@ class NumberMember(Member[_NT, _NULLABLE], Generic[_NT, _NULLABLE]):
             self._element_type = ElementType.FLOAT
             if self.max_value_length == 8:
                 self._element_type |= 1
-        super().__init__(tag, nullable=nullable, **kwargs)
+        super().__init__(tag, optional=optional, nullable=nullable, **kwargs)
 
     def __set__(self, obj, value):
         if value is not None and self.integer:
@@ -355,23 +396,26 @@ class NumberMember(Member[_NT, _NULLABLE], Generic[_NT, _NULLABLE]):
         return offset + self.max_value_length
 
 
-class IntMember(NumberMember[int, _NULLABLE]):
+class IntMember(NumberMember[int, _OPT, _NULLABLE]):
     def __init__(
         self,
         tag,
         *,
         signed: bool = True,
         octets: Literal[1, 2, 4, 8] = 1,
+        optional: _OPT = False,
         nullable: _NULLABLE = False,
         **kwargs,
     ):
         uformat = INT_SIZE[int(math.log2(octets))]
         # little-endian
         self.format = f"<{uformat.lower() if signed else uformat}"
-        super().__init__(tag, _format=self.format, nullable=nullable, **kwargs)
+        super().__init__(
+            tag, _format=self.format, optional=optional, nullable=nullable, **kwargs
+        )
 
 
-class BoolMember(Member[bool, _NULLABLE]):
+class BoolMember(Member[bool, _OPT, _NULLABLE]):
     max_value_length = 0
 
     def decode(self, buffer, length, offset=0):
@@ -390,11 +434,17 @@ class BoolMember(Member[bool, _NULLABLE]):
         return offset
 
 
-class StringMember(Member[AnyStr, _NULLABLE], Generic[AnyStr, _NULLABLE]):
+class StringMember(Member[AnyStr, _OPT, _NULLABLE], Generic[AnyStr, _OPT, _NULLABLE]):
     _base_element_type: ElementType
 
     def __init__(
-        self, tag, max_length, *, optional=False, nullable: _NULLABLE = False, **kwargs
+        self,
+        tag,
+        max_length,
+        *,
+        optional: _OPT = False,
+        nullable: _NULLABLE = False,
+        **kwargs,
     ):
         self.max_value_length = max_length
         length_encoding = int(math.log(max_length, 256))
@@ -403,46 +453,57 @@ class StringMember(Member[AnyStr, _NULLABLE], Generic[AnyStr, _NULLABLE]):
         self.length_length = struct.calcsize(self.length_format)
         super().__init__(tag, optional=optional, nullable=nullable, **kwargs)
 
-    def decode(self, buffer, length, offset=0):
-        return buffer[offset : offset + length]
-
     def _print(self, value):
         return " ".join((f"{byte:02x}" for byte in value))
 
     def encode_element_type(self, value):
         return self._element_type
 
-    def encode_value_into(self, value, buffer, offset) -> int:
+    def encode_value_into(self, value, buffer: bytearray, offset: int) -> int:
         struct.pack_into(self.length_format, buffer, offset, len(value))
         offset += self.length_length
         buffer[offset : offset + len(value)] = value
         return offset + len(value)
 
 
-class OctetStringMember(StringMember[bytes, _NULLABLE]):
+class OctetStringMember(StringMember[bytes, _OPT, _NULLABLE]):
     _base_element_type: ElementType = ElementType.OCTET_STRING
 
+    def decode(self, buffer, length, offset=0):
+        return buffer[offset : offset + length].tobytes()
 
-class UTF8StringMember(StringMember[str, _NULLABLE]):
+
+class UTF8StringMember(StringMember[str, _OPT, _NULLABLE]):
     _base_element_type = ElementType.UTF8_STRING
 
     def decode(self, buffer, length, offset=0):
-        return super().decode(buffer, length, offset).decode("utf-8")
+        return buffer[offset : offset + length].tobytes().decode("utf-8")
 
-    def encode_value_into(self, value, buffer, offset) -> int:
+    def encode_value_into(self, value: str, buffer, offset) -> int:
         return super().encode_value_into(value.encode("utf-8"), buffer, offset)
 
     def _print(self, value):
         return f'"{value}"'
 
 
-class StructMember(Member):
-    def __init__(self, tag, substruct_class, optional=False):
+_TLVStruct = TypeVar("_TLVStruct", bound=TLVStructure)
+
+
+class StructMember(Member[_TLVStruct, _OPT, _NULLABLE]):
+    def __init__(
+        self,
+        tag,
+        substruct_class: Type[_TLVStruct],
+        *,
+        optional: _OPT = False,
+        nullable: _NULLABLE = False,
+        **kwargs,
+    ):
         self.substruct_class = substruct_class
         self.max_value_length = substruct_class.max_length() + 1
-        super().__init__(tag, optional=optional)
+        super().__init__(tag, optional=optional, nullable=nullable, **kwargs)
 
-    def decode(self, buffer, length, offset=0) -> TLVStructure:
+    def decode(self, buffer, length, offset=0):
         return self.substruct_class(buffer[offset : offset + length])
 
     def _print(self, value):
@@ -451,7 +512,7 @@ class StructMember(Member):
     def encode_element_type(self, value):
         return ElementType.STRUCTURE
 
-    def encode_value_into(self, value, buffer, offset) -> int:
+    def encode_value_into(self, value, buffer: bytearray, offset: int) -> int:
         offset = value.encode_into(buffer, offset)
         buffer[offset] = ElementType.END_OF_CONTAINER
         return offset + 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ test = [
     "hypothesis",
     "pytest",
     "pytest-cov",
-    # "typing_extensions",
+    "typing_extensions",
 ]
 
 [tool.coverage.run]

--- a/tests/test_tlv.py
+++ b/tests/test_tlv.py
@@ -289,11 +289,11 @@ class TestOctetString:
 
 
 class Null(tlv.TLVStructure):
-    n = tlv.BoolMember(None, nullable=True, optional=False)
+    n = tlv.BoolMember(None, nullable=True)
 
 
 class NotNull(tlv.TLVStructure):
-    n = tlv.BoolMember(None, nullable=True, optional=False)
+    n = tlv.BoolMember(None, nullable=True)
     b = tlv.BoolMember(None)
 
 
@@ -482,8 +482,8 @@ class TestFloatDouble:
 
 
 class InnerStruct(tlv.TLVStructure):
-    a = tlv.NumberMember(0, "<i", optional=True)
-    b = tlv.NumberMember(1, "<i", optional=True)
+    a = tlv.IntMember(0, signed=True, optional=True, octets=4)
+    b = tlv.IntMember(1, signed=True, optional=True, octets=4)
 
 
 class OuterStruct(tlv.TLVStructure):
@@ -493,6 +493,9 @@ class OuterStruct(tlv.TLVStructure):
 class TestStruct:
     def test_inner_struct_decode(self):
         s = OuterStruct(b"\x15\x20\x00\x2a\x20\x01\xef\x18")
+        assert_type(s, OuterStruct)
+        assert_type(s.s, InnerStruct)
+        assert_type(s.s.a, Optional[int])
         assert str(s) == "{\n  s = {\n    a = 42,\n    b = -17\n  }\n}"
         assert s.s.a == 42
         assert s.s.b == -17


### PR DESCRIPTION
Refactors:
 - looping over Member descriptors
 - calculate String `length_encoding` with a logarithm instead of a loop.


Makes things like this give a type error:

```
class NullTest(tlv.TLVStructure):
    n = tlv.BoolMember(None, nullable=True)
    notn = tlv.BoolMember(None, nullable=False)

s = NullTest()
s.n = None  # checks ok
s.notn = None  # doesn't type check
```

Doesn't handle `StructMember` yet.