### PR TITLE
Adding stricter type annotations

### DIFF
--- a/circuitmatter/__init__.py
+++ b/circuitmatter/__init__.py
@@ -2,9 +2,9 @@
 
 import binascii
 import enum
-import pathlib
 import json
 import os
+import pathlib
 import struct
 import time
 
@@ -112,13 +112,13 @@ PROTOCOL_OPCODES = {
 #  : UNSIGNED INTEGER [ range 16-bits ],
 # }
 class SessionParameterStruct(tlv.TLVStructure):
-    session_idle_interval = tlv.NumberMember(1, "<I", optional=True)
-    session_active_interval = tlv.NumberMember(2, "<I", optional=True)
-    session_active_threshold = tlv.NumberMember(3, "<H", optional=True)
-    data_model_revision = tlv.NumberMember(4, "<H")
-    interaction_model_revision = tlv.NumberMember(5, "<H")
-    specification_version = tlv.NumberMember(6, "<I")
-    max_paths_per_invoke = tlv.NumberMember(7, "<H")
+    session_idle_interval = tlv.IntMember(1, signed=False, octets=4, optional=True)
+    session_active_interval = tlv.IntMember(2, signed=False, octets=4, optional=True)
+    session_active_threshold = tlv.IntMember(3, signed=False, octets=2, optional=True)
+    data_model_revision = tlv.IntMember(4, signed=False, octets=2)
+    interaction_model_revision = tlv.IntMember(5, signed=False, octets=2)
+    specification_version = tlv.IntMember(6, signed=False, octets=4)
+    max_paths_per_invoke = tlv.IntMember(7, signed=False, octets=2)
 
 
 # pbkdfparamreq-struct => STRUCTURE [ tag-order ]
@@ -135,8 +135,8 @@ class SessionParameterStruct(tlv.TLVStructure):
 # }
 class PBKDFParamRequest(tlv.TLVStructure):
     initiatorRandom = tlv.OctetStringMember(1, 32)
-    initiatorSessionId = tlv.NumberMember(2, "<H")
-    passcodeId = tlv.NumberMember(3, "<H")
+    initiatorSessionId = tlv.IntMember(2, signed=False, octets=2)
+    passcodeId = tlv.IntMember(3, signed=False, octets=2)
     hasPBKDFParameters = tlv.BoolMember(4)
     initiatorSessionParams = tlv.StructMember(5, SessionParameterStruct, optional=True)
 
@@ -147,7 +147,7 @@ class PBKDFParamRequest(tlv.TLVStructure):
 # salt [2] : OCTET STRING [ length 16..32 ],
 # }
 class Crypto_PBKDFParameterSet(tlv.TLVStructure):
-    iterations = tlv.NumberMember(1, "<I")
+    iterations = tlv.IntMember(1, signed=False, octets=4)
     salt = tlv.OctetStringMember(2, 32)
 
 
@@ -166,7 +166,7 @@ class Crypto_PBKDFParameterSet(tlv.TLVStructure):
 class PBKDFParamResponse(tlv.TLVStructure):
     initiatorRandom = tlv.OctetStringMember(1, 32)
     responderRandom = tlv.OctetStringMember(2, 32)
-    responderSessionId = tlv.NumberMember(3, "<H")
+    responderSessionId = tlv.IntMember(3, signed=False, octets=2)
     pbkdf_parameters = tlv.StructMember(4, Crypto_PBKDFParameterSet)
     responderSessionParams = tlv.StructMember(5, SessionParameterStruct, optional=True)
 

--- a/circuitmatter/tlv.py
+++ b/circuitmatter/tlv.py
@@ -407,9 +407,41 @@ class IntMember(NumberMember[int, _OPT, _NULLABLE]):
         nullable: _NULLABLE = False,
         **kwargs,
     ):
+        """
+        :param octets: Number of octests to use for encoding.
+                       1, 2, 4, 8 are 8, 16, 32, and 64 bits respectively
+        :param optional: Indicates whether the value MAY be omitted from the encoding.
+                         Can be used for deprecation.
+        :param nullable: Indicates whether a TLV Null MAY be encoded in place of a value.
+        """
+        # TODO 7.18.1 mentions other bit lengths (that are not a power of 2) than the TLV Appendix
         uformat = INT_SIZE[int(math.log2(octets))]
-        # little-endian
+        # < = little-endian
         self.format = f"<{uformat.lower() if signed else uformat}"
+        super().__init__(
+            tag, _format=self.format, optional=optional, nullable=nullable, **kwargs
+        )
+
+
+class FloatMember(NumberMember[float, _OPT, _NULLABLE]):
+    def __init__(
+        self,
+        tag,
+        *,
+        octets: Literal[4, 8] = 4,
+        optional: _OPT = False,
+        nullable: _NULLABLE = False,
+        **kwargs,
+    ):
+        """
+        :param octets: Number of octests to use for encoding.
+                       4, 8 are single and double precision floats respectively.
+        :param optional: Indicates whether the value MAY be omitted from the encoding.
+                         Can be used for deprecation.
+        :param nullable: Indicates whether a TLV Null MAY be encoded in place of a value.
+        """
+        # < = little-endian
+        self.format = f"<{'f' if octets == 4 else 'd'}"
         super().__init__(
             tag, _format=self.format, optional=optional, nullable=nullable, **kwargs
         )


### PR DESCRIPTION
Adds `tlv.FloatMember` and changes the Single precision Float test in test_tlv.. It encoded to 'f' not '<f'. Which raises the question:

            # encoding to LE float32 raises OverflowError outside these ranges
            # TODO: should we raise ValueError with a bounds check or encode -inf/inf?


I've changed the structs in `__init__.py` to use the `IntMember`, so you should get nice type checks in your editor.

PS thanks for the mention in the hug report :blush: 