### PR TITLE
Set LED GPIO direction = OUTPUT

### DIFF
--- a/examples/circuitmatter_simpletest.py
+++ b/examples/circuitmatter_simpletest.py
@@ -11,6 +11,7 @@ class LED(on_off.OnOffLight):
     def __init__(self, name, led):
         super().__init__(name)
         self._led = led
+        self._led.direction = digitalio.Direction.OUTPUT
 
     def on(self, session):
         self._led.value = True


### PR DESCRIPTION
Set LED GPIO direction = `OUTPUT`

Otherwise it returns an error message:
```
Processing message 80613993 for exchange 60661
Received Invoke Request
invoke [[ Endpoint = 1U, Cluster = 6U, Command = 1U]]
invoke OnOff on
Not an output
```